### PR TITLE
Improve API Input Assertion Techniques in Tests

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -22,7 +22,7 @@ const Layout = ({ children }: LayoutProps) => (
 
       <link rel="icon" type="image/png" href="/favicon.png" />
 
-      <title>Nlang Code Editor</title>
+      <title>Nlang Scripting Language</title>
     </Head>
 
     <Flex minH="100vh" minW="100vw" direction="column" px={[4, 6, 10]} py={3}>


### PR DESCRIPTION
Because for now we cannot use MSW with Node.js Version 18, I decided to use another technique to assert that the input and the output are really correct.

The technique:

- Assert that the input / request body is shaped accordingly to the expected behavior.
- Assert that the input / expression that are sent to the API is the same as the expected string (we already have the expected output above when we set everything that are related to this particular test). If the input is the same, then the output will also be the same.

By having these techniques, we don't need to worry whether the output will differ or not, because it should be the same at all times unless the grammar parser changes. Grammar parsers are pure functions.